### PR TITLE
Configure LM Studio endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This repository contains small experiments. The `refine_app.py` script demonstrates how to use [CrewAI](https://crewai.com) together with a simple Gradio interface.
 
-Run the application with:
+Run the application with LM Studio running locally:
 
 ```bash
-OPENAI_API_KEY=your-key python refine_app.py
+python refine_app.py
 ```
 
-The interface will first generate clarifying questions for your initial query. After you provide answers, it produces a refined query.
+Ensure LM Studio's API server is enabled and matches the endpoint and model defined in `constants.py`. The interface will first generate clarifying questions for your initial query. After you provide answers, it produces a refined query.

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,2 @@
+LM_STUDIO_ENDPOINT = "http://localhost:1234/v1"
+LM_STUDIO_MODEL_NAME = "TheBloke/Mistral-7B-Instruct-v0.2-GGUF"

--- a/refine_app.py
+++ b/refine_app.py
@@ -1,11 +1,15 @@
 import os
 import gradio as gr
 from crewai import Agent, Task, Crew
+from constants import LM_STUDIO_ENDPOINT, LM_STUDIO_MODEL_NAME
+import openai
 
-# Ensure API key is provided for the language model
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    raise EnvironmentError("OPENAI_API_KEY environment variable is required")
+# Configure CrewAI and OpenAI client for LM Studio
+os.environ.setdefault("OPENAI_API_KEY", "lm-studio")
+os.environ["OPENAI_BASE_URL"] = LM_STUDIO_ENDPOINT
+os.environ["OPENAI_MODEL_NAME"] = LM_STUDIO_MODEL_NAME
+openai.api_key = os.environ["OPENAI_API_KEY"]
+openai.base_url = LM_STUDIO_ENDPOINT
 
 
 def ask_questions(user_query: str) -> str:


### PR DESCRIPTION
## Summary
- configure LM Studio endpoint and model via `constants.py`
- hook LM Studio settings in `refine_app.py`
- update instructions in README

## Testing
- `python refine_app.py --help` *(fails: No module named 'gradio')*

------
https://chatgpt.com/codex/tasks/task_e_6853de390810832a8ebb4441172ccf1d